### PR TITLE
コメント修正

### DIFF
--- a/PC6001VX.pro
+++ b/PC6001VX.pro
@@ -16,13 +16,13 @@ CONFIG += link_prl c++11
 #Define for Qt dependent code
 DEFINES += QTP6VX
 
-#Disable joystick support.If uncommented below, PC6001VX does not depend on SDL2.
+#Disable joystick support. If uncommented below, PC6001VX does not depend on SDL2.
 #DEFINES += NOJOYSTICK
 
-#Disable joystick support.If uncommented below, PC6001VX does not depend on ffmpeg.
+#Disable video capture support. If uncommented below, PC6001VX does not depend on ffmpeg.
 #DEFINES += NOAVI
 
-#Disable debug features.For low performance machine.
+#Disable debug features. For low performance machine.
 #DEFINES += NOMONITOR
 
 #Other feature control flags.


### PR DESCRIPTION
PC6001VX.pro の以下のコメント修正です。
- NOAVI の説明が joystick のままになっていたのを video capture に修正
- ピリオドの後ろにスペース追加